### PR TITLE
set checkbox id for labels work correctly

### DIFF
--- a/assets/javascripts/wizard/templates/components/wizard-field-checkbox.hbs
+++ b/assets/javascripts/wizard/templates/components/wizard-field-checkbox.hbs
@@ -1,1 +1,1 @@
-{{input type='checkbox' checked=field.value}}
+{{input type='checkbox' id=field.id checked=field.value}}


### PR DESCRIPTION
This PR adds `id` attribute to checkboxes, so they are in sync with label's `for` attribute and work as expected.

**Before**
![](http://recordit.co/Hsx3VCH2Md.gif)

**After**
![](http://recordit.co/0NWfyiWuxi.gif)