### PR TITLE
Remove unused group option from custom-user-search

### DIFF
--- a/assets/javascripts/wizard/components/custom-user-selector.js.es6
+++ b/assets/javascripts/wizard/components/custom-user-selector.js.es6
@@ -81,8 +81,7 @@ export default Ember.TextField.extend({
           includeGroups,
           allowedUsers,
           includeMentionableGroups,
-          includeMessageableGroups,
-          group: self.get("group")
+          includeMessageableGroups
         });
 
         return results;


### PR DESCRIPTION
When https://github.com/discourse/discourse/pull/7538 gets merged, the `group` option will be replaced with `groupMembersOf`. 

This option is not being used so I thought it will be a good idea to remove it.

